### PR TITLE
Bugfix: Expression for `!=null` now allows to specify BSON type.

### DIFF
--- a/src/main/java/org/mongounit/MongoUnitUtil.java
+++ b/src/main/java/org/mongounit/MongoUnitUtil.java
@@ -1528,6 +1528,11 @@ public class MongoUnitUtil {
   private static Comparable expectedToComparable(Object expectedValue, String bsonType)
       throws MongoUnitException {
 
+    // If expected value is null, always return 'null'
+    if (expectedValue == null) {
+      return null;
+    }
+
     try {
 
       // If bsonType isn't specified, just need to cast to Comparable

--- a/src/test/java/org/mongounit/MongoUnitUtilTest.java
+++ b/src/test/java/org/mongounit/MongoUnitUtilTest.java
@@ -82,6 +82,18 @@ class MongoUnitUtilTest {
     assertFalse(assertMatchesMongoUnitValue(mongoUnitValue, 1, "$$").isMatch(), "null != 1");
     assertTrue(assertMatchesMongoUnitValue(mongoUnitValue, null, "$$").isMatch(), "null == null");
 
+    // null for expected value (with BSON type) when actual is and is not null
+    mongoUnitValue.put(COMPARATOR_FIELD_NAME, "=");
+    mongoUnitValue.remove("$$");
+    mongoUnitValue.put("$$DATE_TIME", null);
+    assertTrue(
+        assertMatchesMongoUnitValue(mongoUnitValue, null, "$$").isMatch(),
+        "DATE_TIME null == null");
+    mongoUnitValue.put(COMPARATOR_FIELD_NAME, "!=");
+    assertTrue(
+        assertMatchesMongoUnitValue(mongoUnitValue, "2019-10-28T16:26:10.247Z", "$$").isMatch(),
+        "DATE_TIME null != 2019-10-28T16:26:10.247Z");
+
     // null for actual value
     mongoUnitValue.put(COMPARATOR_FIELD_NAME, "=");
     mongoUnitValue.put("$$", 1);
@@ -205,7 +217,7 @@ class MongoUnitUtilTest {
   @DisplayName("Assertion of non-list, non-map generic expected value.")
   void testAssertMatchesValueSimpleExpected() {
 
-    MongoUnitProperties props = new MongoUnitProperties(null, null, "$$mongounit$$", null, null);
+    MongoUnitProperties props = new MongoUnitProperties(null, null, "$$", null, null);
 
     // numbers
     assertTrue(assertMatchesValue(1, 1, props).isMatch(), "1 = 1");


### PR DESCRIPTION
Expression for `!=null` now allows to specify BSON type.

Closes #5