### PR TITLE
Release 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.mongounit</groupId>
   <artifactId>mongounit</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <name>mongounit</name>
   <description>MongoUnit is a data driven Integration testing framework for Spring Boot based
     applications that use MongoDB for persistence. The framework enables the developer to test the
@@ -46,7 +46,7 @@
     <java.version>8</java.version>
     <maven.compiler.target>8</maven.compiler.target>
     <maven.compiler.source>8</maven.compiler.source>
-    <spring.version>2.2.0.RELEASE</spring.version>
+    <spring.version>2.3.4.RELEASE</spring.version>
   </properties>
 
   <dependencies>
@@ -66,6 +66,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-legacy</artifactId>
+      <version>4.0.5</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.mongounit</groupId>
   <artifactId>mongounit</artifactId>
-  <version>1.2.0</version>
+  <version>2.0.0</version>
   <name>mongounit</name>
   <description>MongoUnit is a data driven Integration testing framework for Spring Boot based
     applications that use MongoDB for persistence. The framework enables the developer to test the

--- a/src/main/java/org/mongounit/DatasetGenerator.java
+++ b/src/main/java/org/mongounit/DatasetGenerator.java
@@ -235,7 +235,7 @@ public class DatasetGenerator {
           collectionNames = extractListArgumentValues(argValue);
 
           // Check if any collection names left; if not, show error to user and exist with error
-          if (collectionNames.size() < 1) {
+          if (collectionNames.isEmpty()) {
 
             // Show error to user and exit with error code
             System.out.println("**** ERROR: if specifying '-collectionNames', must specify at"

--- a/src/main/java/org/mongounit/MongoUnitExtension.java
+++ b/src/main/java/org/mongounit/MongoUnitExtension.java
@@ -32,7 +32,7 @@ import org.opentest4j.AssertionFailedError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
@@ -91,8 +91,8 @@ public class MongoUnitExtension implements
 
     // Retrieve database instance through Spring context
     ApplicationContext springContext = SpringExtension.getApplicationContext(context);
-    MongoDbFactory mongoDbFactory = springContext.getBean(MongoDbFactory.class);
-    MongoDatabase mongoDatabase = mongoDbFactory.getDb();
+    MongoDatabaseFactory mongoDatabaseFactory = springContext.getBean(MongoDatabaseFactory.class);
+    MongoDatabase mongoDatabase = mongoDatabaseFactory.getMongoDatabase();
 
     // Cache the database for this run in case manual seeding and assertion is done
     CURRENT_MONGO_DATABASE = mongoDatabase;

--- a/src/main/java/org/mongounit/MongoUnitTest.java
+++ b/src/main/java/org/mongounit/MongoUnitTest.java
@@ -20,7 +20,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 
 /**
  * {@link MongoUnitTest} is an annotation meant to be placed on JUnit classes to autoconfigure the
- * Spring-based MongoDbFactory to use a test database for the integration tests.
+ * Spring-based MongoDatabaseFactory to use a test database for the integration tests.
  * <p>
  * Placing this annotation on a test class automatically triggers the MongoUnit framework to look
  * for them as system properties or to look for the 'mongounit.properties' file at the root of the

--- a/src/main/java/org/mongounit/config/MongoDatabaseFactoryBean.java
+++ b/src/main/java/org/mongounit/config/MongoDatabaseFactoryBean.java
@@ -13,15 +13,15 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
-import org.springframework.data.mongodb.MongoDbFactory;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 
 /**
- * {@link MongoDbFactoryBean} class is a definition of the MongoUnit specific {@link MongoDbFactory}
+ * {@link MongoDatabaseFactoryBean} class is a definition of the MongoUnit specific {@link MongoDatabaseFactory}
  * bean to be substituted for originally configured one in the Spring context.
  */
-public class MongoDbFactoryBean
-    implements FactoryBean<MongoDbFactory>, EnvironmentAware, InitializingBean {
+public class MongoDatabaseFactoryBean
+    implements FactoryBean<MongoDatabaseFactory>, EnvironmentAware, InitializingBean {
 
   /**
    * Spring environment.
@@ -29,20 +29,20 @@ public class MongoDbFactoryBean
   private Environment environment;
 
   /**
-   * Mongo client URI to use for the new MongoDbFactory bean.
+   * Mongo client URI to use for the new MongoDatabaseFactoryBean bean.
    */
   private MongoClientURI mongoClientURI;
 
   @Override
-  public MongoDbFactory getObject() {
+  public MongoDatabaseFactory getObject() {
 
     // Create new factory based on the calculated URI
-    return new SimpleMongoClientDbFactory(mongoClientURI.getURI());
+    return new SimpleMongoClientDatabaseFactory(mongoClientURI.getURI());
   }
 
   @Override
   public Class<?> getObjectType() {
-    return MongoDbFactory.class;
+    return MongoDatabaseFactory.class;
   }
 
   @Override

--- a/src/main/java/org/mongounit/config/MongoDatabaseGuardConfiguration.java
+++ b/src/main/java/org/mongounit/config/MongoDatabaseGuardConfiguration.java
@@ -17,19 +17,19 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.beans.factory.support.RootBeanDefinition;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.util.ObjectUtils;
 
 /**
- * {@link MongoDbGuardConfiguration} configuration is a bean definition registry post processor that
- * substitutes a custom {@link MongoDbFactory} that modifies the database URI.
+ * {@link MongoDatabaseGuardConfiguration} configuration is a bean definition registry post processor that
+ * substitutes a custom {@link MongoDatabaseFactory} that modifies the database URI.
  */
-public class MongoDbGuardConfiguration implements BeanDefinitionRegistryPostProcessor {
+public class MongoDatabaseGuardConfiguration implements BeanDefinitionRegistryPostProcessor {
 
   /**
    * Logger for this configuration class.
    */
-  private static Logger log = LoggerFactory.getLogger(MongoDbGuardConfiguration.class);
+  private static Logger log = LoggerFactory.getLogger(MongoDatabaseGuardConfiguration.class);
 
   @Override
   public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry)
@@ -45,7 +45,7 @@ public class MongoDbGuardConfiguration implements BeanDefinitionRegistryPostProc
   }
 
   /**
-   * Substitutes {@link MongoDbFactory} bean int the registry.
+   * Substitutes {@link MongoDatabaseFactory} bean int the registry.
    *
    * @param registry Bean registry to substitute the bean in.
    * @param beanFactory Factory to create the bean that will substitute existing one.
@@ -54,32 +54,32 @@ public class MongoDbGuardConfiguration implements BeanDefinitionRegistryPostProc
       BeanDefinitionRegistry registry,
       ConfigurableListableBeanFactory beanFactory) {
 
-    // Retrieve existing MongoDbFactory bean
-    BeanDefinitionHolder holder = getMongoDbFactoryBeanDefinition(beanFactory);
+    // Retrieve existing MongoDatabaseFactory bean
+    BeanDefinitionHolder holder = getMongoDatabaseFactoryBeanDefinition(beanFactory);
 
     if (holder != null) {
       String beanName = holder.getBeanName();
       boolean primary = holder.getBeanDefinition().isPrimary();
 
-      log.info("Replacing '" + beanName + "' MongoDbFactory bean with "
+      log.info("Replacing '" + beanName + "' MongoDatabaseFactory bean with "
           + (primary ? "primary " : "") + "MongoUnit version");
       registry.removeBeanDefinition(beanName);
-      registry.registerBeanDefinition(beanName, createMongoDbFactoryBeanDefinition(primary));
+      registry.registerBeanDefinition(beanName, createMongoDatabaseFactoryBeanDefinition(primary));
     }
   }
 
   /**
    * @param beanFactory Bean factory where to retrieve the existing bean definition for the {@link
-   * MongoDbFactory}.
-   * @return Bean definition holder of the existing {@link MongoDbFactory} in the registry.
+   * MongoDatabaseFactory}.
+   * @return Bean definition holder of the existing {@link MongoDatabaseFactory} in the registry.
    */
-  private BeanDefinitionHolder getMongoDbFactoryBeanDefinition(
+  private BeanDefinitionHolder getMongoDatabaseFactoryBeanDefinition(
       ConfigurableListableBeanFactory beanFactory) {
 
-    String[] beanNames = beanFactory.getBeanNamesForType(MongoDbFactory.class);
+    String[] beanNames = beanFactory.getBeanNamesForType(MongoDatabaseFactory.class);
 
     if (ObjectUtils.isEmpty(beanNames)) {
-      log.info("No MongoDbFactory beans found.");
+      log.info("No MongoDatabaseFactory beans found.");
       return null;
     }
 
@@ -96,17 +96,17 @@ public class MongoDbGuardConfiguration implements BeanDefinitionRegistryPostProc
       }
     }
 
-    log.info("No primary MongoDbFactory found.");
+    log.info("No primary MongoDatabaseFactory found.");
     return null;
   }
 
   /**
    * @param primary Flag to indicate if the bean should be set as primary.
-   * @return Bean definition to replace the existing {@link MongoDbFactory} bean with.
+   * @return Bean definition to replace the existing {@link MongoDatabaseFactory} bean with.
    */
-  private BeanDefinition createMongoDbFactoryBeanDefinition(boolean primary) {
+  private BeanDefinition createMongoDatabaseFactoryBeanDefinition(boolean primary) {
 
-    BeanDefinition beanDefinition = new RootBeanDefinition(MongoDbFactoryBean.class);
+    BeanDefinition beanDefinition = new RootBeanDefinition(MongoDatabaseFactoryBean.class);
     beanDefinition.setPrimary(primary);
     return beanDefinition;
   }

--- a/src/main/java/org/mongounit/config/MongoUnitConfiguration.java
+++ b/src/main/java/org/mongounit/config/MongoUnitConfiguration.java
@@ -8,7 +8,6 @@
  */
 package org.mongounit.config;
 
-import com.mongodb.MongoClientURI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +15,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.Lifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.stereotype.Component;
 
 /**
@@ -38,8 +37,8 @@ public class MongoUnitConfiguration {
    * execution.
    */
   @Bean
-  public static MongoDbGuardConfiguration createDatabaseGuardConfiguration() {
-    return new MongoDbGuardConfiguration();
+  public static MongoDatabaseGuardConfiguration createDatabaseGuardConfiguration() {
+    return new MongoDatabaseGuardConfiguration();
   }
 
   /**
@@ -66,16 +65,16 @@ public class MongoUnitConfiguration {
       // Load mongo properties
       MongoUnitProperties mongoProperties = MongoUnitConfigurationUtil.loadMongoUnitProperties();
 
-      MongoDbFactory mongoDbFactory = applicationContext.getBean(MongoDbFactory.class);
+      MongoDatabaseFactory mongoDatabaseFactory = applicationContext.getBean(MongoDatabaseFactory.class);
 
       // Drop database if not disabled
       if (mongoProperties.isDropDatabase()) {
 
-        log.info("Dropping test database '" + mongoDbFactory.getDb().getName() + "'.");
-        mongoDbFactory.getDb().drop();
+        log.info("Dropping test database '" + mongoDatabaseFactory.getMongoDatabase().getName() + "'.");
+        mongoDatabaseFactory.getMongoDatabase().drop();
       } else {
 
-        log.info("Test database '" + mongoDbFactory.getDb().getName() + "' is NOT dropped. Manual"
+        log.info("Test database '" + mongoDatabaseFactory.getMongoDatabase().getName() + "' is NOT dropped. Manual"
             + " cleanup is necessary to remove it.");
       }
     }

--- a/src/main/java/org/mongounit/config/MongoUnitConfigurationUtil.java
+++ b/src/main/java/org/mongounit/config/MongoUnitConfigurationUtil.java
@@ -134,7 +134,7 @@ public class MongoUnitConfigurationUtil {
     // Create client URI to extract db name only
     String newClientUri = baseUri.replaceFirst(baseUriDbName, newDbName);
 
-    log.info("Using test database with URI: '" + newClientUri + "'.");
+    log.info("Using test database with URI: '{}'.", newClientUri);
 
     return new MongoClientURI(newClientUri);
   }


### PR DESCRIPTION
Many thanks to @JordanHitchman for submitting the fix!

**Spring 2.3.0 dependency fix**

From https://github.com/mongounit/mongounit/pull/16: 

This PR includes fixes for the MongoDbFactory interface deprecation introduced in Spring boot 2.3.0.

This interface has been superseded by the parent interface MongoDatabaseFactory. SimpleMongoClientDbFactory has also been superseded by SimpleMongoClientDatabaseFactory. All instances of the deprecated interfaces have been updated.

It felt natural to update the wrapper config classes to use the full domain name as well, so all instances of 'Db' referenced in the config classes have been updated to 'Database', e.g. MongoDbFactory -> MongoDatabaseFactory.
If this is unwanted then I will revert back.

I'm not too familiar with this Maven set up so I wasn't sure how best to update the Javadocs, my attempts to run the tasks failed, so some guidance here would be appreciated if this needs updating.

Summary -

MongoDbFactory -> MongoDatabaseFactory
SimpleMongoClientDbFactory -> SimpleMongoClientDatabaseFactory