### PR TITLE
Update mongodb dependency to 5.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <java.version>8</java.version>
     <maven.compiler.target>8</maven.compiler.target>
     <maven.compiler.source>8</maven.compiler.source>
-    <spring.version>2.3.4.RELEASE</spring.version>
+    <spring.version>3.3.0</spring.version>
   </properties>
 
   <dependencies>
@@ -71,11 +71,6 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver-legacy</artifactId>
-      <version>5.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-sync</artifactId>
       <version>5.0.1</version>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,12 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver-legacy</artifactId>
-      <version>4.0.5</version>
+      <version>5.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-sync</artifactId>
+      <version>5.0.1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>8</java.version>
-    <maven.compiler.target>8</maven.compiler.target>
-    <maven.compiler.source>8</maven.compiler.source>
+    <java.version>17</java.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <spring.version>3.3.0</spring.version>
   </properties>
 

--- a/src/main/java/org/mongounit/MongoUnitUtil.java
+++ b/src/main/java/org/mongounit/MongoUnitUtil.java
@@ -176,12 +176,11 @@ public class MongoUnitUtil {
   public static void dropAllCollectionsInDatabase(MongoDatabase mongoDatabase) {
 
     // Iterate over all collections in the db and drop them
-    for (String collectionName : mongoDatabase.listCollectionNames()) {
-
+    mongoDatabase.listCollectionNames().forEach(collectionName -> {
       mongoDatabase.getCollection(collectionName).drop();
 
       log.trace("Dropped collection " + collectionName);
-    }
+    });
   }
 
   /**
@@ -261,13 +260,9 @@ public class MongoUnitUtil {
    */
   private static List<String> getCollectionNames(MongoDatabase mongoDatabase) {
 
-    List<String> collectionNames = new ArrayList<>();
-
     // Retrieve collection names from db
-    for (String collectionName : mongoDatabase.listCollectionNames()) {
-      collectionNames.add(collectionName);
-    }
-
+    List<String> collectionNames = new ArrayList<>();
+    mongoDatabase.listCollectionNames().forEach(collectionNames::add);
     return collectionNames;
   }
 


### PR DESCRIPTION
Spring boot 3.3.X update use org.mongodb 5.0.1

This PR fix a breaking change related to mongodb 5.X.X : https://www.mongodb.com/docs/drivers/java/sync/v5.0/whats-new/#std-label-version-5.0
![image](https://github.com/mongounit/mongounit/assets/27289886/9db60183-8206-45f2-9690-96693096efa6)
The com.mongodb.client.MongoDatabase.listCollectionNames() return type changed. This PR adapt the MongoUnitUtil code to this change.